### PR TITLE
Fix indentation for marshalling sgml

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -746,6 +746,7 @@ func (p *printer) writeEnd(name Name) error {
 	p.tags = p.tags[:len(p.tags)-1]
 	if sortedContains(p.disableAutoClose, name.Local) {
 		p.popPrefix()
+		p.writeIndent(-2)
 		return nil
 	}
 


### PR DESCRIPTION
I left a bug in the indentation implementation 😬 
This PR fixes the indentation so instead of no dedent, we get the correct double dedent after a non-closing sgml element.

before:
```xml
<thing>
    <a>
        <b>some B</a>
    </thing>
```

after:
```xml
<thing>
    <a>
        <b>some B
    </a>
</thing>
```